### PR TITLE
feat(todo/user): add user-service and todo-service (in-memory, trusts…

### DIFF
--- a/auth-microservice/todo-service/handler.go
+++ b/auth-microservice/todo-service/handler.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+    "net/http"
+    "strconv"
+
+    "github.com/labstack/echo/v4"
+)
+
+type addTodoReq struct {
+    Text string `json:"text"`
+}
+
+func ListTodosHandler(repo *TodoRepo) echo.HandlerFunc {
+    return func(c echo.Context) error {
+        owner := c.Request().Header.Get("X-User-Email")
+        if owner == "" {
+            return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user"})
+        }
+        todos := repo.ListByOwner(owner)
+        return c.JSON(http.StatusOK, todos)
+    }
+}
+
+func AddTodoHandler(repo *TodoRepo) echo.HandlerFunc {
+    return func(c echo.Context) error {
+        owner := c.Request().Header.Get("X-User-Email")
+        if owner == "" {
+            return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user"})
+        }
+        var req addTodoReq
+        if err := c.Bind(&req); err != nil {
+            return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request"})
+        }
+        t := repo.Add(owner, req.Text)
+        return c.JSON(http.StatusCreated, t)
+    }
+}
+
+func DeleteTodoHandler(repo *TodoRepo) echo.HandlerFunc {
+    return func(c echo.Context) error {
+        owner := c.Request().Header.Get("X-User-Email")
+        if owner == "" {
+            return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user"})
+        }
+        idStr := c.Param("id")
+        id, err := strconv.Atoi(idStr)
+        if err != nil {
+            return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid id"})
+        }
+        ok := repo.Delete(owner, id)
+        if !ok {
+            return c.JSON(http.StatusNotFound, map[string]string{"error": "not found or not allowed"})
+        }
+        return c.NoContent(http.StatusNoContent)
+    }
+}

--- a/auth-microservice/todo-service/main.go
+++ b/auth-microservice/todo-service/main.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/labstack/echo/v4"
+
+func main() {
+    e := echo.New()
+    repo := NewTodoRepo()
+
+    e.GET("/todos", ListTodosHandler(repo))
+    e.POST("/todos", AddTodoHandler(repo))
+    e.DELETE("/todos/:id", DeleteTodoHandler(repo))
+
+    e.Logger.Fatal(e.Start(":8083"))
+}

--- a/auth-microservice/todo-service/model.go
+++ b/auth-microservice/todo-service/model.go
@@ -1,0 +1,8 @@
+package main
+
+// Todo represents a simple todo item owned by an email.
+type Todo struct {
+    ID    int    `json:"id"`
+    Owner string `json:"owner"`
+    Text  string `json:"text"`
+}

--- a/auth-microservice/todo-service/repository.go
+++ b/auth-microservice/todo-service/repository.go
@@ -1,0 +1,46 @@
+package main
+
+import "sync"
+
+type TodoRepo struct {
+    mu    sync.Mutex
+    items map[int]Todo
+    next  int
+}
+
+func NewTodoRepo() *TodoRepo {
+    return &TodoRepo{items: make(map[int]Todo), next: 1}
+}
+
+func (r *TodoRepo) ListByOwner(owner string) []Todo {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    var out []Todo
+    for _, t := range r.items {
+        if t.Owner == owner {
+            out = append(out, t)
+        }
+    }
+    return out
+}
+
+func (r *TodoRepo) Add(owner, text string) Todo {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    id := r.next
+    r.next++
+    t := Todo{ID: id, Owner: owner, Text: text}
+    r.items[id] = t
+    return t
+}
+
+func (r *TodoRepo) Delete(owner string, id int) bool {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    t, ok := r.items[id]
+    if !ok || t.Owner != owner {
+        return false
+    }
+    delete(r.items, id)
+    return true
+}

--- a/auth-microservice/user-service/handler.go
+++ b/auth-microservice/user-service/handler.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+    "net/http"
+
+    "github.com/labstack/echo/v4"
+)
+
+// GetProfile reads the forwarded X-User-Email header and returns the user profile.
+func GetProfile(repo *UserRepo) echo.HandlerFunc {
+    return func(c echo.Context) error {
+        email := c.Request().Header.Get("X-User-Email")
+        if email == "" {
+            return c.JSON(http.StatusUnauthorized, map[string]string{"error": "missing user header"})
+        }
+        user, err := repo.GetByEmail(email)
+        if err != nil {
+            return c.JSON(http.StatusNotFound, map[string]string{"error": "user not found"})
+        }
+        return c.JSON(http.StatusOK, user)
+    }
+}

--- a/auth-microservice/user-service/main.go
+++ b/auth-microservice/user-service/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+    "log"
+
+    "github.com/labstack/echo/v4"
+)
+
+func main() {
+    e := echo.New()
+    repo := NewUserRepo()
+
+    e.GET("/profile", GetProfile(repo))
+
+    log.Println("user-service listening on :8084")
+    e.Logger.Fatal(e.Start(":8084"))
+}

--- a/auth-microservice/user-service/model.go
+++ b/auth-microservice/user-service/model.go
@@ -1,0 +1,9 @@
+package main
+
+// User represents a simple user profile stored in the user-service.
+type User struct {
+    ID    int    `json:"id"`
+    Email string `json:"email"`
+    Name  string `json:"name"`
+    Role  string `json:"role"`
+}

--- a/auth-microservice/user-service/repository.go
+++ b/auth-microservice/user-service/repository.go
@@ -1,0 +1,23 @@
+package main
+
+import "errors"
+
+// simple in-memory repository
+type UserRepo struct {
+    users map[string]User // key by email
+}
+
+func NewUserRepo() *UserRepo {
+    r := &UserRepo{users: make(map[string]User)}
+    // seed with an example user
+    r.users["alice@example.com"] = User{ID: 1, Email: "alice@example.com", Name: "Alice", Role: "user"}
+    r.users["admin@example.com"] = User{ID: 2, Email: "admin@example.com", Name: "Admin", Role: "admin"}
+    return r
+}
+
+func (r *UserRepo) GetByEmail(email string) (User, error) {
+    if u, ok := r.users[email]; ok {
+        return u, nil
+    }
+    return User{}, errors.New("user not found")
+}


### PR DESCRIPTION
This pull request introduces two new microservices to the `auth-microservice` project: a todo management service and a user profile service. Both services use Echo for HTTP routing and maintain in-memory repositories for their respective data. The todo service allows authenticated users (via the `X-User-Email` header) to manage their todo items, while the user service provides access to user profiles based on the same header.

**Todo Service Implementation**

* Adds a new todo service with HTTP handlers for listing, adding, and deleting todos, all requiring user authentication via the `X-User-Email` header (`handler.go`, `main.go`). [[1]](diffhunk://#diff-596277dc5512719e175596637ccdf7d2bff47db7fcaa96653e0c0d51d7bae4dfR1-R57) [[2]](diffhunk://#diff-a071f17fe4f2cc510af9cdbc0c0d211b0e4fd3eab850f84d375631af2035849cR1-R14)
* Implements an in-memory, thread-safe repository for todo items, supporting owner-based filtering and access control (`repository.go`).
* Defines the `Todo` model representing a todo item with an owner, text, and ID (`model.go`).

**User Service Implementation**

* Adds a user profile service with an endpoint to return the authenticated user's profile based on the `X-User-Email` header (`handler.go`, `main.go`). [[1]](diffhunk://#diff-4db03cee63f2f574d45292dce84ded66bea1abf5397bf5c20eefb0a87657c82eR1-R22) [[2]](diffhunk://#diff-7d977563823b7700662e64db689fe484cff7296b6c9dff6ab6d8068810d89bc8R1-R17)
* Implements an in-memory user repository seeded with example users and provides lookup by email (`repository.go`).
* Defines the `User` model containing ID, email, name, and role fields (`model.go`).… gateway headers)
[Copilot is generating a summary...]